### PR TITLE
Added level 3 to tolerance

### DIFF
--- a/src/auto_abi_checker/auto-abi.py
+++ b/src/auto_abi_checker/auto-abi.py
@@ -118,7 +118,7 @@ def get_abi_checker_version():
 def main():
     try:
         version = "0.1.14"
-        tolerance_levels = "12"
+        tolerance_levels = "123"
         cmd_executed = ' '.join(argv[:])
         args = normalize_args(docopt(__doc__, version="auto-abi " + version))
         validate_input(args)


### PR DESCRIPTION
This PR should fix this issue https://github.com/osrf/auto-abi-checker/issues/23 in the buildfarm http://build.ros2.org/job/Fpr__rcpputils__ubuntu_focal_amd64/4/consoleFull#console-section-15

I don't know if this may affect to other packages. @j-rivero Is there any way to run all foxy abi checkers?

Signed-off-by: ahcorde <ahcorde@gmail.com>