### PR TITLE
make copytree robust to symlinks in the packages

### DIFF
--- a/src/auto_abi_checker/auto-abi.py
+++ b/src/auto_abi_checker/auto-abi.py
@@ -90,7 +90,9 @@ def process_input(args, cmd_executed, tolerance_levels):
         new_gen = generator.generate(new_type, 'new')
         new_gen.run(new_value)
 
-        abi_exe = ABIExecutor(tolerance_levels)
+        # TODO(tfoote) EVN hack for the moment add this as a commandline
+        compilation_flags = os.getenv('COMPILATION_FLAGS', default='')
+        abi_exe = ABIExecutor(tolerance_levels, compilation_flags=compilation_flags)
         abi_exe.run(src_gen,
                     new_gen,
                     report_dir,

--- a/src/auto_abi_checker/auto-abi.py
+++ b/src/auto_abi_checker/auto-abi.py
@@ -32,6 +32,7 @@ Options:
 """
 
 import datetime
+import os
 import re
 import subprocess
 from sys import stderr, argv

--- a/src/auto_abi_checker/srcs_local.py
+++ b/src/auto_abi_checker/srcs_local.py
@@ -28,7 +28,7 @@ class SrcLocalDir(SrcBase):
 
     def copy_files(self, directory):
         info("Run copytree from  " + directory + " to " + self.ws_files)
-        copytree(directory, self.ws_files symlinks=True, ignore_dangling_symlinks=True)
+        copytree(directory, self.ws_files, symlinks=True, ignore_dangling_symlinks=True)
 
     def filter_files(self):
         True

--- a/src/auto_abi_checker/srcs_local.py
+++ b/src/auto_abi_checker/srcs_local.py
@@ -28,7 +28,7 @@ class SrcLocalDir(SrcBase):
 
     def copy_files(self, directory):
         info("Run copytree from  " + directory + " to " + self.ws_files)
-        copytree(directory, self.ws_files)
+        copytree(directory, self.ws_files symlinks=True, ignore_dangling_symlinks=True)
 
     def filter_files(self):
         True


### PR DESCRIPTION
This will keep the symlinks and make it robust to symlinks that don't resolve.